### PR TITLE
Fix build dependendencies for amd64

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -37,6 +37,11 @@ RUN echo 'deb http://ftp.debian.org/debian stretch main contrib non-free' > /etc
     apt-get update && \
     apt-get -t stretch install -y \
                 libfst-tools \
+                libc6 \
+                gfortran \
+                g++ \
+                libtool \
+                python-dev \
         --no-install-recommends && \
     rm -r /var/lib/apt/lists/* && \
     rm /etc/apt/sources.list.d/stretch.list

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The simplest way to start is with the following command:
 
 ```bash
 docker run \
-    -it
+    -it \
     --name jasper \
     --privileged \
     --volume /dev/snd/pcmC0D0p:/dev/snd/pcmC1D0p \


### PR DESCRIPTION
I suspect that declaring those additional libs in `stretch` might but be updating more stuff than needed, but this was a quick way to solve #1  as of today.